### PR TITLE
Bugfix fix string decoding

### DIFF
--- a/src/libs/ros_echronos/Message_Descriptor.cpp
+++ b/src/libs/ros_echronos/Message_Descriptor.cpp
@@ -78,6 +78,9 @@ void Message_Descriptor::decode_msg(const can::CAN_ROS_Message &msg) {
             field_size[field_offset] |= *curr_bdy;
             ++i;
             decoding_len = false;
+            _Array * array = ((_Array *) field_ptrs[field_internal_offset]);
+            array->override_with_new_size(field_size[field_offset]);
+            field_ptrs[field_offset] = array->get_values_ptr();
             continue;
         }
         curr_field_size-=field_internal_offset;

--- a/src/libs/ros_echronos/Message_Descriptor.cpp
+++ b/src/libs/ros_echronos/Message_Descriptor.cpp
@@ -77,6 +77,7 @@ void Message_Descriptor::decode_msg(const can::CAN_ROS_Message &msg) {
             //this should always be the first byte in the message
             field_size[field_offset] |= *curr_bdy;
             ++i;
+            decoding_len = false;
             continue;
         }
         curr_field_size-=field_internal_offset;

--- a/src/libs/ros_echronos/build_tools/msg_gen.py
+++ b/src/libs/ros_echronos/build_tools/msg_gen.py
@@ -536,7 +536,7 @@ def write_virtual_functions(s, spec, cpp_name_prefix):
     for field in spec.parsed_fields():
 
         (base_type, is_array, array_len) = roslib.msgs.parse_type(field.type)
-        if is_array:
+        if is_array or (base_type == 'string'):
             sizes.append("%s.bytes+2" % field.name)
             output+='      memcpy(block+offset, &%s.size, sizeof(short));\n' % (field.name)
             output+='      memcpy(block+offset+sizeof(short), &%s.values, %s.bytes);\n' % (field.name, field.name)
@@ -559,7 +559,7 @@ def write_virtual_functions(s, spec, cpp_name_prefix):
     for field in spec.parsed_fields():
         (base_type, is_array, array_len) = roslib.msgs.parse_type(field.type)
         s.write('    descriptor->fixed_field_ptrs[%d] = &%s;\n' % (i, field.name))
-        if is_array:
+        if is_array or (base_type == 'string'):
             s.write('    descriptor->fixed_field_sizes[%d] = 0;\n' % (i))
         else:
             s.write('    descriptor->fixed_field_sizes[%d] = sizeof(%s);\n' % (i, field.name))

--- a/src/modules/ros_sub_test/CMakeLists.txt
+++ b/src/modules/ros_sub_test/CMakeLists.txt
@@ -23,4 +23,6 @@ set(CPP_FILES ros_sub_test.cpp)
 add_module(ros_sub_test 4 1 0 "${CPP_FILES}")
 target_link_libraries(ros_sub_test pwm servo m)
 
+generate_msgs(std_msgs String)
+depend_msgs(ros_sub_test std_msgs String)
 


### PR DESCRIPTION
Ros python lib doesn't consider strings to be arrays, we must have broken this at some point