### PR TITLE
ROC-23 got advertise ctrl message working correctly

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/usr/share/catkin/cmake/toplevel.cmake
+/opt/ros/kinetic/share/catkin/cmake/toplevel.cmake

--- a/src/libs/ros_echronos/NodeHandle.cpp
+++ b/src/libs/ros_echronos/NodeHandle.cpp
@@ -106,6 +106,8 @@ void NodeHandle::do_register_node(char *node_name, RtosSignalId msg_signal) {
         ((On_Error_Data*)data)->this_node->do_register_node(((On_Error_Data*)data)->node_name, ((On_Error_Data*)data)->msg_signal);
         ROS_INFO("CAN Error\n");
     }, &on_error_data)->wait(msg_signal);
+    
+    ROS_INFO("Node init done");
 }
 
 void NodeHandle::spin() {

--- a/src/libs/ros_echronos/include/can/advertise_topic.hpp
+++ b/src/libs/ros_echronos/include/can/advertise_topic.hpp
@@ -40,7 +40,7 @@ namespace ros_echronos {
             /**
              * Ctrl message specific fields that are common
              */
-            constexpr CAN_Header _adv_ctrl_fields = {
+            constexpr CAN_Header adv_ctrl_fields = {
                 .fields = {
                     .f2_ctrl_msg_fields = {
                         0x0, ((unsigned int)ADVERTISE_TOPIC), 0
@@ -52,7 +52,7 @@ namespace ros_echronos {
              * Merged CAN Header
              */
             const CAN_Header ADV_CTRL_HEADER {
-                .bits = CAN_CTRL_BASE_FIELDS.bits | _adv_ctrl_fields.bits
+                .bits = CAN_CTRL_BASE_FIELDS.bits | adv_ctrl_fields.bits
             };
 
             /**
@@ -68,6 +68,13 @@ namespace ros_echronos {
 
             inline uint8_t send_string(can::CAN_ROS_Message & msg, Advertise_Header & msg_head, char  * const  start_str_ptr, const uint32_t str_len, const uint32_t index_offset) {
                 return control_2_subscribe::send_string(msg, msg_head, start_str_ptr, str_len, index_offset);
+            }
+            
+            constexpr CAN_Header add_common_headers(const Advertise_Header & advertise_header) {
+                return {
+                        .bits = CAN_CTRL_BASE_FIELDS.bits | advertise_header.bits | adv_ctrl_fields.bits
+                    };
+
             }
         }
     }

--- a/src/modules/boilerplate/boilerplate.c
+++ b/src/modules/boilerplate/boilerplate.c
@@ -1,4 +1,7 @@
 #include "boilerplate.h"
+#define CAN_BITRATE 500000
+
+
 
 void nmi() { for(;;); }
 
@@ -89,4 +92,30 @@ void * memset(void * dst, int c, size_t n) {//__attribute__((used)) {
         ptr[i] = c;
     }
     return ptr;
+}
+
+void init_can_common(void) {
+    // We enable GPIO E - E4 for RX and E5 for TX
+    SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOE);
+    GPIOPinConfigure(GPIO_PE4_CAN0RX);
+    GPIOPinConfigure(GPIO_PE5_CAN0TX);
+
+    // enables the can function we have just configured on those pins
+    GPIOPinTypeCAN(GPIO_PORTE_BASE, GPIO_PIN_4 | GPIO_PIN_5);
+
+    //enable and initalise CAN0
+    SysCtlPeripheralEnable(SYSCTL_PERIPH_CAN0);
+    CANInit(CAN0_BASE);
+
+    //TODO: change this to use the eChronos clock
+    // Set the bitrate for the CAN BUS. It uses the system clock
+    CANBitRateSet(CAN0_BASE, ROM_SysCtlClockGet(), CAN_BITRATE);
+
+    // enable can interupts
+    CANIntEnable(CAN0_BASE, CAN_INT_MASTER | CAN_INT_ERROR); //| CAN_INT_STATUS);
+    IntEnable(INT_CAN0);
+
+    //start CAN
+    CANEnable(CAN0_BASE);
+
 }

--- a/src/modules/boilerplate/boilerplate.h
+++ b/src/modules/boilerplate/boilerplate.h
@@ -23,6 +23,7 @@
 #include "driverlib/interrupt.h"
 #include "utils/uartstdio.h"
 
+#define CAN_MSG_LEN 8
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,6 +35,11 @@ void InitializeFPU(void);
 
 
 void fatal(const uint8_t error_id);
+
+/**
+ * Common initialisation for can
+ */
+void init_can_common(void);
 
 #ifdef __cplusplus
 }

--- a/src/modules/left_locomotion/left_locomotion.cpp
+++ b/src/modules/left_locomotion/left_locomotion.cpp
@@ -24,8 +24,7 @@
 
 #define SYSTICKS_PER_SECOND     100
 
-#define CAN_BITRATE 500000
-#define CAN_MSG_LEN 8
+
 
 static tCANMsgObject rx_object;
 static uint8_t can_input_buffer[CAN_MSG_LEN];
@@ -150,7 +149,7 @@ int main(void) {
     // Initialize the UART for stdio so we can use UARTPrintf
     InitializeUARTStdio();
 
-    init_can();
+    init_can_common();
 
     alloc::init_mm(RTOS_MUTEX_ID_ALLOC);
 
@@ -164,32 +163,6 @@ int main(void) {
     /* Should never reach here, but if we do, an infinite loop is
        easier to debug than returning somewhere random. */
     for (;;) ;
-}
-
-void init_can(void) {
-    // We enable GPIO E - E4 for RX and E5 for TX
-    SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOE);
-    GPIOPinConfigure(GPIO_PE4_CAN0RX);
-    GPIOPinConfigure(GPIO_PE5_CAN0TX);
-
-    // enables the can function we have just configured on those pins
-    GPIOPinTypeCAN(GPIO_PORTE_BASE, GPIO_PIN_4 | GPIO_PIN_5);
-
-    //enable and initalise CAN0
-    SysCtlPeripheralEnable(SYSCTL_PERIPH_CAN0);
-    CANInit(CAN0_BASE);
-
-    //TODO: change this to use the eChronos clock
-    // Set the bitrate for the CAN BUS. It uses the system clock
-    CANBitRateSet(CAN0_BASE, ROM_SysCtlClockGet(), CAN_BITRATE);
-
-    // enable can interupts
-    CANIntEnable(CAN0_BASE, CAN_INT_MASTER | CAN_INT_ERROR); //| CAN_INT_STATUS);
-    IntEnable(INT_CAN0);
-
-    //start CAN
-    CANEnable(CAN0_BASE);
-
 }
 
 static duty_pct speed_to_duty_pct(double speed) {

--- a/src/modules/ros_test/ros_test.cpp
+++ b/src/modules/ros_test/ros_test.cpp
@@ -29,49 +29,16 @@ bool sent_message;
 
 static uint32_t error_flag;
 
-/**
- * Used to handle interups from can0
- */
-extern "C" void can0_int_handler(void) {
-    uint32_t can_status = 0;
-
-    // read the register
-    can_status = CANIntStatus(CAN0_BASE, CAN_INT_STS_CAUSE);
-
-    // in this case we are reciving a status interupt
-    if(can_status == CAN_INT_INTID_STATUS) {
-        // read the error status and store it to be handled latter
-        error_flag = CANStatusGet(CAN0_BASE, CAN_STS_CONTROL);
-        // clear so we can continue
-        CANIntClear(CAN0_BASE, 1);
-    } else {
-        // we are reciving a message, TODO: handle this
-        // for now we clear the interup so we can continue
-        CANIntClear(CAN0_BASE, 1);
-
-        // clear the error flag (otherwise we will store recive or write statuses)
-        error_flag = 0;
-
-        // if we haven't just sent a message read.
-        if(!sent_message) {
-            CANMessageGet(CAN0_BASE, can_status, &rx_object, 0);
-            UARTprintf("Received: %c\n", can_input_buffer);
-        }
-        sent_message = false;
-    }
-
-    //UARTprintf("A Error Code %x\n", can_status);
-}
-
 extern "C" void task_ros_test_fn(void) {
 
     UARTprintf("Entered CAN task. Initializing...\n");
     ros_echronos::NodeHandle nh;
+    nh.init("ros_test_fn", "ros_test_fn", RTOS_INTERRUPT_EVENT_ID_CAN_RECEIVE_EVENT,  RTOS_SIGNAL_ID_CAN_RECEIVE_SIGNAL, RTOS_SIGNAL_ID_ROS_PROMISE_SIGNAL);
     UARTprintf("Done init\n");
-    nh.init("ros_test_fn", "ros_test_fn", RTOS_INTERRUPT_EVENT_ID_CAN_RECEIVE_EVENT, 0, RTOS_SIGNAL_ID_ROS_PROMISE_SIGNAL);
 
     UARTprintf("pub init\n");
     pub->init(nh, RTOS_SIGNAL_ID_ROS_PROMISE_SIGNAL);
+     UARTprintf("pub init done\n");
     owr_messages::pwm msg;
     msg.currentPos=0.0;
     msg.targetPos=0.0;
@@ -111,9 +78,12 @@ int main(void) {
     ros_echronos::Publisher<owr_messages::pwm> _pub("aaa", (owr_messages::pwm*)pwm_buffer, 5, false);
     pub = &_pub;
 
-    init_can();
+    init_can_common();
 
     alloc::init_mm(RTOS_MUTEX_ID_ALLOC);
+    
+    ros_echronos::write_mutex = RTOS_MUTEX_ID_PRINT;
+    ros_echronos::write_mutex_set = true;
 
     // Actually start the RTOS
     UARTprintf("Starting RTOS...\n");
@@ -124,47 +94,3 @@ int main(void) {
     for (;;) ;
 }
 
-void init_can(void) {
-    // We enable GPIO E - E4 for RX and E5 for TX
-    SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOE);
-    GPIOPinConfigure(GPIO_PE4_CAN0RX);
-    GPIOPinConfigure(GPIO_PE5_CAN0TX);
-
-    // enables the can function we have just configured on those pins
-    GPIOPinTypeCAN(GPIO_PORTE_BASE, GPIO_PIN_4 | GPIO_PIN_5);
-
-    //enable and initalise CAN0
-    SysCtlPeripheralEnable(SYSCTL_PERIPH_CAN0);
-    CANInit(CAN0_BASE);
-
-    //TODO: change this to use the eChronos clock
-    // Set the bitrate for the CAN BUS. It uses the system clock
-    CANBitRateSet(CAN0_BASE, ROM_SysCtlClockGet(), CAN_BITRATE);
-
-    // enable can interupts
-    CANIntEnable(CAN0_BASE, CAN_INT_MASTER | CAN_INT_ERROR );
-    IntEnable(INT_CAN0);
-
-    //start CAN
-    CANEnable(CAN0_BASE);
-
-    // enable an object for reciving the latest messages
-    // 0 for Msg ID and Filter means recieve all messages
-    // for ROS I'm thinking we have a message id per topic
-    rx_object.ui32MsgID = 0;
-    rx_object.ui32MsgIDMask = 0;
-    rx_object.ui32Flags = MSG_OBJ_TX_INT_ENABLE;
-    rx_object.ui32MsgLen = CAN_MSG_LEN;
-    rx_object.pui8MsgData = (uint8_t *) &can_input_buffer;
-}
-
-void write_can(uint32_t message_id, uint8_t *buffer, uint32_t buffer_size) {
-    tCANMsgObject can_tx_message;
-    can_tx_message.ui32MsgID = message_id;
-    can_tx_message.ui32MsgIDMask = 0;
-    can_tx_message.ui32Flags = MSG_OBJ_TX_INT_ENABLE;
-    can_tx_message.ui32MsgLen = buffer_size;
-    can_tx_message.pui8MsgData = buffer;
-
-    CANMessageSet(CAN0_BASE, message_id, &can_tx_message, MSG_OBJ_TYPE_TX);
-}

--- a/src/modules/ros_test/ros_test.prx
+++ b/src/modules/ros_test/ros_test.prx
@@ -25,6 +25,10 @@
                     <number>39</number>
                     <handler>ros_can_interupt_handler</handler>
                 </external_irq>
+                <external_irq>
+                    <number>5</number>
+                    <handler>uart0_int_handler</handler>
+                </external_irq>
             </external_irqs>
         </module>
         <module name="armv7m.semihost-debug" />
@@ -44,7 +48,7 @@
                     <name>task_ros_test</name>
                     <function>task_ros_test_fn</function>
                     <priority>30</priority>
-                    <stack_size>512</stack_size>
+                    <stack_size>2048</stack_size>
                 </task>
 		 <task>
                     <name>task_can_wait</name>
@@ -79,6 +83,9 @@
                 <mutex>
                     <name>alloc</name>
                 </mutex>
+                <mutex>
+                    <name>print</name>
+                </mutex>
             </mutexes>
 
             <mutex>
@@ -88,7 +95,7 @@
                 <interrupt_event>
                     <name>can_receive_event</name>
                     <sig_set>can_receive_signal</sig_set>
-                    <task>task_ros_test</task>
+                    <task>task_can_wait</task>
                 </interrupt_event>
             </interrupt_events>
         </module>


### PR DESCRIPTION
Note that actually sending messages once control is working is breaking in a way that causes seg faults - I'm reasonably confident this is because its sending messages that aren't expected though. 

I also moved the can initialization code to the boilerplate to remove one more thing that's duplicated in lots of places