### PR TITLE
fix integer division issue in message_size()

### DIFF
--- a/src/libs/ros_echronos/Message.cpp
+++ b/src/libs/ros_echronos/Message.cpp
@@ -50,7 +50,8 @@ uint16_t Message::message_size() {
         // we don't know the size in messages until we have generated the block
         generate_block();
     }
-    return size / can::CAN_MESSAGE_MAX_LEN;
+    uint8_t floored = size / can::CAN_MESSAGE_MAX_LEN;
+    return size % can::CAN_MESSAGE_MAX_LEN == 0 ? floored : floored + 1;
 }
 
 Message::Message(const Message & message) {


### PR DESCRIPTION
Function is used by the publisher to determine how many CAN messages to send for a message.
This was returning 0 for messages less than 8 bytes (uint8, uint16, etc).
It should return 1 for everything up to and including 64bit types