### PR TITLE
fix generate_block_impl() for array messages

### DIFF
--- a/src/libs/ros_echronos/build_tools/msg_gen.py
+++ b/src/libs/ros_echronos/build_tools/msg_gen.py
@@ -539,7 +539,7 @@ def write_virtual_functions(s, spec, cpp_name_prefix):
         if is_array or (base_type == 'string'):
             sizes.append("%s.bytes+2" % field.name)
             output+='      memcpy(block+offset, &%s.size, sizeof(short));\n' % (field.name)
-            output+='      memcpy(block+offset+sizeof(short), &%s.values, %s.bytes);\n' % (field.name, field.name)
+            output+='      memcpy(block+offset+sizeof(short), %s.values, %s.bytes);\n' % (field.name, field.name)
             output+='      offset+=%s.bytes+sizeof(short);\n' % (field.name)
         else:
             sizes.append("sizeof(%s)" % field.name)


### PR DESCRIPTION
for an array, `array.values` is the pointer to its data. the `memcpy` here is copying data to the block from _the address of that pointer_ instead of just that pointer, which is invalid. the size copying is fine though