### PR TITLE
misc fixes

### DIFF
--- a/src/libs/ros_echronos/include/ros.hpp
+++ b/src/libs/ros_echronos/include/ros.hpp
@@ -197,10 +197,12 @@ template <typename T> inline  ros_echronos::Array<T> & ros_echronos::Array<T>::o
         alloc::free(values);
     }
     size = new_value.size;
+    bytes = size * sizeof(T);
     if(size!=0) {
-        bytes = size * sizeof(T);
         values = (T*) alloc::malloc(bytes);
         memcpy(values, new_value.values, bytes);
+    } else {
+        values = NULL;
     }
     return *this;
 }

--- a/src/libs/ros_echronos/templates/Publisher.cpp
+++ b/src/libs/ros_echronos/templates/Publisher.cpp
@@ -139,7 +139,7 @@ template <class T> void Publisher<T>::register_topic(const RtosSignalId signal_w
     const uint8_t index_offset = control_4_advertise::send_string(msg, msg_head, topic_name, topic_length+1, 0);
     const uint8_t index = control_4_advertise::send_string(msg, msg_head, T::NAME, msg_name_len+1, index_offset+1);
     // if we haven't just sent a message and its not the last null terminator, send
-    if((index != (CAN_MESSAGE_MAX_LEN-1)) && (index != 0)) {
+    if(index != (CAN_MESSAGE_MAX_LEN-1)) {
         msg.body_bytes = index+1;
         send_can(msg);
     }


### PR DESCRIPTION
fix in `Publisher.cpp` is the same as https://github.com/bluesat/numbat-embedded/pull/20, except it's for the publisher

fix in `ros.hpp`: when an array is copied via `operator=`, `bytes` is not set to 0 if the new `size` is 0, and `values` is not set to `NULL`