### PR TITLE
Roc 24 control messasge reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,6 @@ venv.bak/
 # mypy
 .mypy_cache/
 .vscode/
+
+# ROS
+src/CMakeLists.txt

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,1 +1,0 @@
-/usr/share/catkin/cmake/toplevel.cmake

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/kinetic/share/catkin/cmake/toplevel.cmake
+/usr/share/catkin/cmake/toplevel.cmake

--- a/src/libs/ros_echronos/NodeHandle.cpp
+++ b/src/libs/ros_echronos/NodeHandle.cpp
@@ -7,13 +7,17 @@
  * @copyright: Copyright BLUEsat UNSW, 2017
  */
 
+
 #include "boilerplate.h"
+#include "driverlib/sysctl.h"
+
 #include "include/NodeHandle.hpp"
 #include "include/Publisher.hpp"
 #include "include/Subscriber.hpp"
 #include "include/can_impl.hpp"
 #include "include/can.hpp"
 #include "include/can/register_node.hpp"
+#include "include/can/channel_control.hpp"
 #include <atomic>
 
 
@@ -178,12 +182,27 @@ void NodeHandle::run_handle_message_loop() {
 
                 }
             } else if (msg.head.fields.base_fields.ros_function == (unsigned int) FN_ROS_CONTROL_MSG) {
-                //TODO: do control message things...
+                // handle channel control messages (messages not triggered by us)
+                if(msg.head.fields.f2_ctrl_msg_fields.mode == (unsigned int)CHANNEL_CONTROL) {
+                    handle_channel_msg(msg);
+                }
             } else {
                 ROS_INFO("Recived Unmatched Header %x", msg.head.bits);
             }
         } while (more);
         // ^ the above loop allows us to handle big messages much more effectively
+    }
+}
+
+void NodeHandle::handle_channel_msg(const ros_echronos::can::CAN_ROS_Message &msg) const {
+    using namespace ros_echronos::can::control_9_channel_control;
+
+    const Channel_Control_Header * const header = (Channel_Control_Header *) &msg;
+
+    if(header->fields.channel_ctrl_mode == RESET) {
+        SysCtlReset();
+    } else {
+        ROS_INFO("Received unrecognised channel control message %x", header->bits);
     }
 }
 

--- a/src/libs/ros_echronos/NodeHandle.cpp
+++ b/src/libs/ros_echronos/NodeHandle.cpp
@@ -33,6 +33,7 @@ ros_echronos::NodeHandle * volatile nh_ptr = NULL;
 
 void NodeHandle::init(char *node_name, char *ros_task, RtosInterruptEventId can_interupt_event,
                       RtosSignalId can_interupt_signal, RtosSignalId register_node_signal) {
+    can::init_channel_ctrl_sub();
     ros_echronos::ROS_INFO("can interupt event %d\n", can_interupt_event);
     can::can_interupt_event = can_interupt_event;
     can_receive_signal = can_interupt_signal;
@@ -200,6 +201,7 @@ void NodeHandle::handle_channel_msg(const ros_echronos::can::CAN_ROS_Message &ms
     const Channel_Control_Header * const header = (Channel_Control_Header *) &msg;
 
     if(header->fields.channel_ctrl_mode == RESET) {
+        ROS_INFO("Received reset control message");
         SysCtlReset();
     } else {
         ROS_INFO("Received unrecognised channel control message %x", header->bits);

--- a/src/libs/ros_echronos/include/NodeHandle.hpp
+++ b/src/libs/ros_echronos/include/NodeHandle.hpp
@@ -105,6 +105,12 @@ namespace ros_echronos {
 
             uint8_t node_id : NODE_ID_WIDTH;
 
+            /**
+             * Function for handling incoming channel control messages
+             * @param msg the message
+             */
+            void handle_channel_msg(const ros_echronos::can::CAN_ROS_Message & msg) const;
+
     };
 }
 

--- a/src/libs/ros_echronos/include/can.hpp
+++ b/src/libs/ros_echronos/include/can.hpp
@@ -74,7 +74,7 @@ namespace ros_echronos {
                 ADVERTISE_SERVICE = 6,
                 DEREGISTER_SERIVCE = 7,
                 MANAGE_PARAMETERS = 8,
-                HEARTBEAT = 9,
+                CHANNEL_CONTROL = 9,
                 EXTENDED = 10
          } Ctrl_Function;
 	 

--- a/src/libs/ros_echronos/include/can.hpp
+++ b/src/libs/ros_echronos/include/can.hpp
@@ -137,7 +137,7 @@ namespace ros_echronos {
                     0,
                     ((unsigned int) FN_ROS_CONTROL_MSG),
                     0,
-		    0
+                    0
                 }
             }
         };

--- a/src/libs/ros_echronos/include/can.hpp
+++ b/src/libs/ros_echronos/include/can.hpp
@@ -148,7 +148,7 @@ namespace ros_echronos {
         constexpr CAN_Header _CTRL_HEADER_MASK_BASE_FIELDS {
             .fields = {
                 .base_fields = {
-                    1, 0xFFFF, 0xFFFF, 0xFFF, 0x0
+                    1, 0x0000, 0xFFFF, 0xFFF, 0x0
                 }
             }
         };

--- a/src/libs/ros_echronos/include/can/channel_control.hpp
+++ b/src/libs/ros_echronos/include/can/channel_control.hpp
@@ -1,0 +1,50 @@
+/*
+ * @date: 3/07/18
+ * @author: (original author) Harry J.E Day <harry@dayfamilyweb.com>
+ * @authors: (editors) 
+ * @details: Header for messages used by for control function 2 (subscribe)
+ * @copydetails: This code is released under the LGPLv3 and newer License and the BSD License
+ * @copyright: Copyright BLUEsat UNSW 2017
+ */
+
+#include "include/can.hpp"
+
+#ifndef PROJECT_SUBSCRIBE_TOPIC_H
+#define PROJECT_SUBSCRIBE_TOPIC_H
+namespace ros_echronos {
+    namespace can {
+        namespace control_9_channel_control {
+            typedef union _channel_control_header {
+                uint32_t  bits;
+                struct _fields {
+                    unsigned int : HEADER_COMMON_BITS;
+                    unsigned int channel_ctrl_mode : 4;
+                    unsigned int node_id : 4;
+                    /**
+                     * Optional, currently only used for heartbeat
+                     */
+                    unsigned int step : 1;
+                } fields __attribute__((packed));
+            } Channel_Control_Header;
+
+            typedef enum _channel_control_sub_mode {
+                RESET = 0,
+                HEARTBEAT = 1
+            } Channel_Control_Sub_Mode;
+
+            /**
+             * Ctrl message specific field values that are common
+             */
+            constexpr CAN_Header CHANNEL_CTRL_CTRL_FIELDS_HEADER {
+                .fields = {
+                    .f2_ctrl_msg_fields = {
+                        ((unsigned int)CHANNEL_CONTROL), 0u
+                    }
+                }
+            };
+
+        }
+
+    }
+}
+#endif //PROJECT_SUBSCRIBE_TOPIC_H

--- a/src/libs/ros_echronos/include/can/channel_control.hpp
+++ b/src/libs/ros_echronos/include/can/channel_control.hpp
@@ -38,7 +38,7 @@ namespace ros_echronos {
             constexpr CAN_Header CHANNEL_CTRL_CTRL_FIELDS_HEADER {
                 .fields = {
                     .f2_ctrl_msg_fields = {
-                        ((unsigned int)CHANNEL_CONTROL), 0u
+                        0u, ((unsigned int)CHANNEL_CONTROL), 0u
                     }
                 }
             };

--- a/src/libs/ros_echronos/include/can_impl.hpp
+++ b/src/libs/ros_echronos/include/can_impl.hpp
@@ -67,6 +67,11 @@ namespace ros_echronos {
         void can_receive_unlock();
 
         /**
+         * Creates a subscription for channel control messages
+         */
+        void init_channel_ctrl_sub();
+
+        /**
          * Incoming can msg buffer
          */
         extern _Incoming_Message_Buffer * incoming_msg_buffer;
@@ -75,6 +80,7 @@ namespace ros_echronos {
          * The "subscription" that can be used for control messages
          */
         extern const can_sub_id CTRL_SUB_ID;
+        extern const can_sub_id CHANNEL_CTRL_SUB_ID;
     }
 }
 


### PR DESCRIPTION
Add support for the reset ctrl message so we can handle the controller starting after the embedded system. 
This also adds the foundation for the other channel control messages (currently just heartbeat in the spec).